### PR TITLE
[Fix] Mobile 편의성

### DIFF
--- a/component/common/CommonDescription.tsx
+++ b/component/common/CommonDescription.tsx
@@ -99,7 +99,12 @@ function Description({ description }: PropsWithChildren<{ description: IRow.Desc
         </li>
       );
     }
-    return <li style={getFontWeight(weight)}>{content}</li>;
+    return (
+      <>
+        <meta name="format-detection" content="telephone=no" />
+        <li style={getFontWeight(weight)}>{content}</li>
+      </>
+    );
   })();
 
   return component;

--- a/component/skill/row.tsx
+++ b/component/skill/row.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, useState, useEffect } from 'react';
 import { Row, Col, Badge } from 'reactstrap';
 import { ISkill } from './ISkill';
 import { Style } from '../common/Style';
@@ -8,6 +8,19 @@ export default function SkillRow({
   skill,
   index,
 }: PropsWithChildren<{ skill: ISkill.Skill; index: number }>) {
+  const [isVerticalScreen, setIsVerticalScreen] = useState(false);
+
+  useEffect(() => {
+    setIsVerticalScreen(window.innerHeight > window.innerWidth);
+    const handleResize = () => {
+      setIsVerticalScreen(window.innerHeight > window.innerWidth);
+    };
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
   return (
     <div>
       {index > 0 ? <hr /> : ''}
@@ -17,14 +30,15 @@ export default function SkillRow({
         </Col>
         <Col sm={12} md={9}>
           {/* {skill.items.map((item) => JSON.stringify(item, null, 2))} */}
-          {createCalculatedSkillItems(skill.items)}
+          {createCalculatedSkillItems(skill.items, isVerticalScreen)}{' '}
+          {/* isVerticalScreen을 인자로 전달 */}
         </Col>
       </Row>
     </div>
   );
 }
 
-function createCalculatedSkillItems(items: ISkill.Item[]) {
+function createCalculatedSkillItems(items: ISkill.Item[], isVerticalScreen: boolean) {
   const log = Util.debug('SkillRow:createCalculatedSkillItems');
 
   /**
@@ -43,6 +57,25 @@ function createCalculatedSkillItems(items: ISkill.Item[]) {
 
   log('origin', items, items.length, splitPoint);
   log('list', list);
+
+  if (isVerticalScreen) {
+    return (
+      <Row className="mt-2 mt-md-0">
+        <Col xs={12}>
+          <ul>
+            {items.map((skill, skillIndex) => {
+              return (
+                <li key={skillIndex.toString()}>
+                  {createBadge(skill.level)}
+                  {skill.title}
+                </li>
+              );
+            })}
+          </ul>
+        </Col>
+      </Row>
+    );
+  }
 
   return (
     <Row className="mt-2 mt-md-0">


### PR DESCRIPTION
안녕하세요 @uyu423 님.
개발하신 템플릿 유용하게 사용하고 있습니다.

템플릿 사용 중 어색한 포맷을 약간 수정했습니다.

+ [[Format] Mobile 환경에서 Skill 항목의 문장 간 간격이 상이한 현상](https://github.com/Zerohertz/resume/issues/2)
+ [[Format] Mobile 환경에서 Patent Number가 번호로 인식되어 파란색으로 표기되는 현상](https://github.com/Zerohertz/resume/issues/3)

여담으로 [`Footer.Component`](https://github.com/uyu423/resume-nextjs/blob/master/pages/index.tsx#L39)를 제거하고 템플릿을 사용해도 될까요?
출처는 레포지토리에 명시하도록 하겠습니다.

감사합니다.